### PR TITLE
Updating frontend dependencies to include eventsource-parser

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.0",
         "antd": "^5.20.3",
+        "eventsource-parser": "^2.0.1",
         "lodash": "^4.17.21",
         "marked": "^14.1.2",
         "react": "^18.3.1",
@@ -8378,6 +8379,15 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-2.0.1.tgz",
+      "integrity": "sha512-gMaRLm5zejEH9mNXC54AnIteFI9YwL/q5JKMdBnoG+lEI1JWVGFVk0Taaj9Xb5SKgzIBDZoQX5IzMe44ILWODg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
     "antd": "^5.20.3",
+    "eventsource-parser": "^2.0.1",
     "lodash": "^4.17.21",
     "marked": "^14.1.2",
     "react": "^18.3.1",


### PR DESCRIPTION
### Problem
Observed an issue while trying to run ```poetry run fbuild``` to test out changes locally.
```Error: Module not found: Error: Can't resolve 'eventsource-parser' in '/Volumes/workplace/SpyZiyaAmz-BTPT/src/SpyZiya/frontend/src/apis'```

### Summary
- Added ```eventsource-parser": ^2.0.1``` to frontend package.json file 

### Testing
```poetry run fbuild``` is successful & server startup as well. 