### PR TITLE
Ensure new file mode exists for new file creation.

### DIFF
--- a/app/utils/code_util.py
+++ b/app/utils/code_util.py
@@ -83,9 +83,18 @@ def correct_git_diff(git_diff: str, original_file_path: str) -> str:
     """
     # Split the diff into lines
     lines = git_diff.split('\n')
+    is_new_file = False
+    # Check if this is a new file creation
+    if lines and lines[0].startswith('diff --git a/dev/null'):
+        is_new_file = True
+        # Check if 'new file mode 100644' is present in the first few lines
+        has_file_mode = any('new file mode 100' in line for line in lines[:3])
+        if not has_file_mode:
+            # Insert the missing line after the first line
+            mode_line = 'new file mode 100644'
+            lines.insert(1, mode_line)
+            logger.info(f"Added missing '{mode_line}' to new file diff")
 
-    # Check if this is a new file creation by looking for "new file mode" in the diff
-    is_new_file = any('new file mode 100644' in line for line in lines[:5])
     original_content = []
 
     if not is_new_file:

--- a/tests/util/test_code_util.py
+++ b/tests/util/test_code_util.py
@@ -235,3 +235,40 @@ def test_correct_git_diff_file_not_found():
 
     with pytest.raises(FileNotFoundError):
         correct_git_diff(diff, "nonexistent.txt")
+
+
+@pytest.mark.parametrize("test_case, input_diff", [
+    (
+        "new file without mode",
+        """diff --git a/dev/null b/new_file.txt
+--- /dev/null
++++ b/new_file.txt
+@@ -0,0 +1,3 @@
++Line 1
++Line 2
++Line 3""",
+    ),
+    (
+        "new file with mode",
+        """diff --git a/dev/null b/new_file.txt
+new file mode 100644
+--- /dev/null
++++ b/new_file.txt
+@@ -0,0 +1,3 @@
++Line 1
++Line 2
++Line 3""",
+    )
+])
+def test_correct_git_diff_new_file(test_case, input_diff):
+    """Test handling of new file diffs with and without mode line."""
+    expected_diff = """diff --git a/dev/null b/new_file.txt
+new file mode 100644
+--- /dev/null
++++ b/new_file.txt
+@@ -0,0 +1,3 @@
++Line 1
++Line 2
++Line 3"""
+    corrected_diff = correct_git_diff(input_diff, "new_file.txt")
+    assert corrected_diff == expected_diff


### PR DESCRIPTION
For new file creation, `new file mode 100644` may be missing. Add a logic to check it and fix the diff. 

A unit test is added.