### PR TITLE
Fix: Update development server to watch correct directory

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,9 +2,8 @@ import argparse
 import os
 import subprocess
 import sys
+import uvicorn
 from typing import Optional
-
-from langchain_cli.cli import serve
 
 from app.utils.logging_utils import logger
 from app.utils.langchain_validation_util import validate_langchain_vars
@@ -96,8 +95,7 @@ def start_server(args):
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     # Override the default server location from 127.0.0.1 to 0.0.0.0
     # This allows the server to be accessible from other machines on the network
-    serve(host="0.0.0.0", port=args.port)
-
+    uvicorn.run("app.server:app", host="0.0.0.0", port=args.port, reload=True, reload_dirs=[os.environ["ZIYA_USER_CODEBASE_DIR"]])
 
 def main():
     args = parse_arguments()


### PR DESCRIPTION
## Problem
The development server was watching the installed package directory (`site-packages/app`) instead of the actual user's codebase directory. This made the auto-reload feature ineffective during development as it wasn't detecting changes in the user's working directory.

## Solution
- Replace langchain's `serve()` with direct `uvicorn.run()` configuration
- Use `ZIYA_USER_CODEBASE_DIR` environment variable (which points to the user's current working directory) for the reload_dirs parameter
- Remove dependency on langchain-cli for serving

## Testing
Before: Server watched `/path/to/site-packages/app` After: Server watches the actual working directory where ziya is run from

This change makes the development experience better by properly reloading the server when files in the user's codebase are modified.